### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,25 @@
+## Sistema de gestión trasera basado en NestJs
+
+Incluye usuarios y roles básicos. Autenticación de inicio de sesión (jwt).
+
+## Datos de la base de datos
+
+[Baidu Netdisk](https://pan.baidu.com/s/1OFmt-ec6v3QjVzpj3RiX9g?pwd=6666)
+
+## Modo de ejecución
+
+```
+pnpm install
+```
+
+```
+pnpm start:dev
+```
+
+## Dirección de la interfaz frontal conectada
+
+<https://github.com/zhang771/NestAdmin-Soybean.git>
+
+## Dirección del documento de API (ApiFox)
+
+<https://www.apifox.cn/apidoc/shared-db747bb9-d703-4064-bfbb-e5be3d1bc9d4>


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `inclusionai/ling-3.0-flash:free` via OpenRouter.